### PR TITLE
misc(readme): add link to Neodymium

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -414,6 +414,7 @@ Other awesome open source projects that use Lighthouse.
 * **[webpack-lighthouse-plugin](https://github.com/addyosmani/webpack-lighthouse-plugin)** - Run Lighthouse from a Webpack build.
 * **[cypress-audit](https://github.com/mfrachet/cypress-audit)** - Run Lighthouse and Pa11y audits directly in your E2E test suites.
 * **[laravel-lighthouse](https://github.com/adityadees/laravel-lighthouse)** - Google Lighthouse wrapper for laravel framework to run Google Lighthouse CLI with custom option and can automatically save result in your server directory.
+* **[Neodymium](https://github.com/Xceptance/neodymium/wiki/Accessibility)** - The Neodymium test automation framework integrates Lighthouse for accessibility and Web Vitals verification, allowing programmatic validation and assertion of all audit values.
 
 ## FAQ
 


### PR DESCRIPTION
**Summary**
Summary
Added the Neodymium test automation tool (MIT licensed) and its support for Lighthouse report and audit value assertions to the README.

This is a small README/documentation update only, just to spread the word which other open-source project integrates Lighthouse.

The wiki of the project that mentions the Lighthouse integration: https://github.com/Xceptance/neodymium/wiki/Accessibility and a blog post with another screenshot: https://blog.xceptance.com/2025/02/11/neodymium-5-1-get-more-done-faster/

**Related Issues/PRs**
Replaced #16330
